### PR TITLE
Handle missing documents

### DIFF
--- a/source/update_value.py
+++ b/source/update_value.py
@@ -245,15 +245,22 @@ def updateFile(operation, db, collection_name, update_file, name, method):
                         else:
                             print(f"Field '{update_field}' already exists and has the same value in document with stable_id: {value_to_match}. No update required.")
                     else:
-                        print(f"The document with '{field_to_match}': {value_to_match} is not in the collection.")
-                
+                        print(f"The document with '{field_to_match}': {value_to_match} is not in the collection. Creating new document.")
+                        
+                        # If the document doesn't exist, create a new one with the specified field and value                        
+                        temp_document = {
+                            field_to_match: value_to_match,
+                            update_field: new_value_list
+                        }
+                        collection.insert_one(temp_document)
+                        updates_made += 1
+
                 # Log the results of updates
                 if updates_made > 0:
                     print(f"Total number of updates made: {updates_made}.")
                 else:
                     log_functions.deleteLog(db, str(process_id))
-                    print(f"No changes were made.")
-                    
+                    print(f"No changes were made.")    
             else:
                 print(f"{f} is not a CSV file.")
         print("Updates finished!")


### PR DESCRIPTION
Several changes were made to update_value.py and insert.py so that the biomongo environment has a proper way of dealing with missing documents when performing bulk updates.


update_value.py:
-	creates a “temporary” document in “update_with_file” operations in case a document is not already present in the database 
-	this “temporary” document only contains the stable_id and the field-value information that is the result of the “update” operation


insert.py:
-	makes a copy of the old document and compares that copy with the new document 
-	if there are differences
o	adds new fields that exist in the new document to the copy (old document)
o	leaves untouched the fields present in the old document that are not present in the new document
o	for fields present in both documents, the function overwrites the content of the fields in the copy with the values present in the new document 
o	keeps the content of the “_id”, “stable_id” and “log” fields untouched 
o	creates two different log entries, one just for insertion and another just for overwritten files 
