### PR TITLE
restore and update upgrades

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,7 @@ update_field='' # Target field to be updated (for update_one and update_all).
 new_value='' # New value for the field (for update_one and update_all).
 update_criteria={'stable_id':''} # Criteria for update_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value.
 # If using update_with_file please provide the path of the CSV/JSON with the information or the path of the directory with the CSVs/JSONs.  
-update_file = ''
+update_file=''
 # Important to consider
 ## If you want to add a list as a new value, separate the values with ";".
 ## If you want to modify an embedded/nested field, use dot notation (e.g. archived_at.crg)  
@@ -37,8 +37,9 @@ update_file = ''
 # Restore needs:
 # ----------
 restore_field='' # Target field to be restored (for restore_one and restore_all).
+log_id='' # log_id to the version to be restored (for restore_one and restore_all).
 restore_criteria={'stable_id':''} # Criteria for restore_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value. 
-log_id='' # Log id to the version to be restored (restore_all only needs this field).
+
 
 # ---------
 # Add empty field needs:

--- a/conf.py
+++ b/conf.py
@@ -36,6 +36,7 @@ update_file = ''
 # ----------
 # Restore needs:
 # ----------
+restore_field='' # Target field to be restored (for restore_one and restore_all).
 restore_criteria={'stable_id':''} # Criteria for restore_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value. 
 log_id='' # Log id to the version to be restored (restore_all only needs this field).
 

--- a/source/restore_value.py
+++ b/source/restore_value.py
@@ -43,13 +43,12 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
         log_functions.deleteLog(db, str(process_id))
         print(f"log_id {log_id} not found in document.")
         return
-
-    # Find the target field entry in the log
-    target_field_log = next((mf for mf in logs[target_log_index].get("modified_fields", [])
-                             if mf.get("field") == field_name), None)
-    if not target_field_log:
+    
+    # Check if the operation is valid for restoration
+    log_operation = logs[target_log_index].get("operation", "").lower()
+    if not (log_operation.startswith("update") or log_operation.startwith("restore")):
         log_functions.deleteLog(db, str(process_id))
-        print(f"Field '{field_name}' not found in log {log_id}.")
+        print("Only update or restore operations can be restored.")
         return
 
     # Get current field value
@@ -58,27 +57,35 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
         current_value = current_value.get(key, None) if isinstance(current_value, dict) else None
         if current_value is None:
             break
+    
+    # Initialize restored_value as a list
+    restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else [] 
 
-    # Normalize to list for easier added/removed operations
-    if isinstance(current_value, list):
-        restored_value = current_value.copy()
-    elif current_value is None:
-        restored_value = []
-    else:
-        restored_value = [current_value]
+    looped_logs = 0 # Counter for logs processed
 
-    # Walk backwards through logs from latest down to (and including) target log
-    for log in reversed(logs[target_log_index:]):
-        field_entry = next((mf for mf in log.get("modified_fields", [])
-                            if mf.get("field") == field_name), None)
+    # Loop through logs from latest to target log
+    for log in logs:
+        if log.get("log_id") == log_id:
+            break
+
+        looped_logs += 1
+        print(f"Processing log entry {looped_logs}")
+
+        # Find the field entry in the modified fields
+        field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None) 
         if not field_entry:
             continue
 
-        added = field_entry.get("added", [])
-        removed = field_entry.get("removed", [])
+        added = field_entry.get("added", []) # List of values added in this log entry
+        removed = field_entry.get("removed", []) # List of values removed in this log entry
 
-        # Reverse the change: remove 'added' values, re-add 'removed' values
+        print(f"Current value from this log entry: {restored_value}")
+        print(f"Added values: {added}")
+        print(f"Removed values: {removed}") 
+
+        # Reverse the change: remove added, re-add removed
         restored_value = [x for x in restored_value if x not in added] + removed
+        print(f"Restored value after processing this log entry: {restored_value}")
 
     # Convert back to original type if it was not a list
     if not isinstance(current_value, list) and len(restored_value) <= 1:
@@ -96,92 +103,91 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
 
     # Check if the update was successful
     if result.modified_count:
-        print(f"Restored '{field_name}' to the value from log {log_id}.")
+        print(f"Field {field_name} successfully restored to the value at log_id: {log_id}.")
     else:
         print("No changes were made.")
 
-def restoreAll(operation, db, collection_name, log_id, name, method):
+def restoreAll(operation, db, collection_name, field_name, log_id, name, method):
     """
     Reset a field (embedded or non-embedded) in all documents in the collection to a previous version using log_id.
     """
     # Access the collection:
     collection = db[collection_name]
 
-    # Retrieve all documents in the collection
-    documents = collection.find()
-
-    # Insert metadata about the restore process in the meta collection
+    # Insert metadata about the restore process in the log_details collection
     process_id = log_functions.insertLog(db, name, method, operation, collection_name)
-    if not process_id:
-        print('Failed to create log for the restore process.')
-        return
 
     restored_documents = 0
     
-    for document in documents:
-        log_entries = document.get('log', [])
+    # Iterate through all documents in the collection
+    for doc in collection.find():
+        # Retrieve the logs 
+        logs = doc.get("log", [])
+        target_log_index = None
+
+        # Find the target log entry by log_id
+        for i, log in enumerate(logs):
+            if log.get("log_id") == log_id:
+                target_log_index = i
+                break
         
-        # Find the log entry to restore
-        log_entry = next((entry for entry in log_entries if entry.get('log_id') == log_id), None)
-        
-        if not log_entry:
-            print(f"The log_id {log_id} does not exist in the document with _id {document['_id']}")
+        # If the log_id is not found, skip this document
+        if target_log_index is None:
+            print(f"log_id {log_id} not found in document {doc.get('stable_id')}")
             continue
 
-        if 'update' not in log_entry.get('operation') and 'restore' not in log_entry.get('operation'):
-            print(f"Only update|restore operations can be restored in document with _id {document['_id']}")
+        # Check if the operation is valid for restoration
+        log_operation = logs[target_log_index].get("operation", "").lower()
+        if not (log_operation.startswith("update") or log_operation.startswith("restore")):
+            print(f"Only update or restore operations can be restored. Skipping document {doc.get('stable_id')}")
             continue
 
-        # Get the field and value to restore
-        modified_field = log_entry.get('modified_field')
-
-        # Retrieve current value (handle embedded fields)
-        current_value = document
-        for key in modified_field.split("."):
-            current_value = current_value.get(key, None)
+        # Get current field value
+        current_value = doc
+        for key in field_name.split("."):
+            current_value = current_value.get(key, None) if isinstance(current_value, dict) else None
             if current_value is None:
                 break
-        
-        current_value_list = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
-        
-        looped_logs = 0
-        restored_value_list = current_value_list
 
-        # Loop through log entries to compute the restored value
-        for entry in log_entries:
-            if entry.get('log_id') == log_id:
+        # Initialize restored_value as a list
+        restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
+
+        looped_logs = 0  # Counter for logs processed
+
+        # Loop through logs from latest to target log
+        for log in logs:
+            if log.get("log_id") == log_id:
                 break
+            
+            looped_logs += 1
 
-            if entry.get('modified_field') == modified_field:
-                looped_logs += 1
-                added_value_list = entry.get('changed_values', {}).get('added', [])
-                removed_value_list = entry.get('changed_values', {}).get('removed', [])
+            # Find the field entry in the modified fields
+            field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None)
+            if not field_entry:
+                continue
 
-                # Compute the restored value
-                restored_value_list = [x for x in restored_value_list if x not in added_value_list] + removed_value_list
-        
-        # Convert single-element lists to a normal string
-        restored_value_list = restored_value_list[0] if len(restored_value_list) == 1 else restored_value_list
+            added = field_entry.get("added", []) # List of values added in this log entry
+            removed = field_entry.get("removed", []) # List of values removed in this log entry
 
-        # Check if the restored value is equal to the current value
-        if restored_value_list == current_value or restored_value_list == current_value_list:
-            print(f"No changes needed for document stable_id {document['stable_id']}, the current value is already equal to the restored value.")
-            continue
+            # Reverse the change: remove added, re-add removed
+            restored_value = [x for x in restored_value if x not in added] + removed
 
-        # Create the log object for this operation
-        updated_log = log_functions.updateLog(document, process_id, operation, modified_field, current_value, restored_value_list)
+        # Convert back to original type if needed
+        if not isinstance(current_value, list) and len(restored_value) <= 1:
+            restored_value = restored_value[0] if restored_value else None
 
-        # Update the document
-        result = collection.update_one(
-            {"_id": document["_id"]},
-            {"$set": {modified_field: restored_value_list, "log": updated_log}}
-        )
+        # Check if the restored value is different from the current value
+        if restored_value != current_value:
+            # Update the log with the restoration details
+            updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)
+            # Update the document with the restored value and updated log 
+            result = collection.update_one({"_id": doc["_id"]}, {"$set": {field_name: restored_value, "log": updated_log}}) 
+            if result.modified_count:
+                restored_documents += 1
 
-        if result.modified_count > 0:
-            restored_documents += 1
-    
+    # Check if any documents were restored
     if restored_documents == 0:
         log_functions.deleteLog(db, str(process_id))
         print("No changes were made.")
     else:
-        print(f'Field {modified_field} restored successfully to the values at log {log_id} in {restored_documents} documents.')
+        print(f"Field {field_name} successfully restored to the values at log {log_id} in {restored_documents} documents.")

--- a/source/update_value.py
+++ b/source/update_value.py
@@ -60,17 +60,15 @@ def updateOne(operation, db, collection_name, update_criteria, update_field, new
         # If the field doesn't exist in the document, explicitly set `None` as the current value
         if current_value is None:
             print(f"Field {update_field} doesn't exist or has no value in the document. Creating field and setting new value.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [None]}
         elif current_value != new_value_list:
             print(f"Field {update_field} exists and has a different value in document with stable_id: {list(update_criteria.values())[0]}. Updating the field.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [current_value]}
         else:
             print(f"Field {update_field} exists but has the same value in document with stable_id: {list(update_criteria.values())[0]}. No update required.")
             log_functions.deleteLog(db, str(process_id))
             return  # Exit the function without performing the update if values are the same
 
         # Update the log with the modified field
-        updated_log = log_functions.updateLogNew(previous_document, process_id, operation, modified_field)
+        updated_log = log_functions.updateLog(previous_document, process_id, operation, update_field, current_value if current_value is not None else None, new_value_list)
         # Update the document with the new data
         result = collection.update_one(update_criteria, {"$set": {update_field: new_value_list, "log": updated_log}})
             
@@ -130,19 +128,16 @@ def updateAll(operation, db, collection_name, update_field, new_value, name, met
         if current_value is None:
             # If the field is set as Null or doesn't exist, create it and set the new value
             print(f"Field {update_field} doesn't exist or has no value in document with stable_id: {stable_id}. Creating field and setting new value.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [None]}
-
         elif current_value != new_value_list:
             # If the field exists but the value is different, update it
             print(f"Field {update_field} exists and has a different value in document with stable_id: {stable_id}. Updating the field.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [current_value]}
         else:
             # If the field exists and the value is the same, no update is needed
             print(f"Field {update_field} exists but has the same value in document with stable_id: {stable_id}. No update required.")
             continue  # Skip to the next document if no update is needed
 
         # Update the log with the modified field
-        updated_log = log_functions.updateLogNew(document, process_id, operation, modified_field)
+        updated_log = log_functions.updateLog(document, process_id, operation, update_field, current_value if current_value is not None else None, new_value_list)
         # Prepare the bulk update operation
         bulk_updates.append(UpdateOne({"_id": document["_id"]}, {"$set": {update_field: new_value_list, "log": updated_log}}))
 

--- a/tools.py
+++ b/tools.py
@@ -25,6 +25,7 @@ def connect_mongo():
     try:
         # Connect to MongoDB
         client = MongoClient(mongoConnection.mongo_host, mongoConnection.mongo_port, username=mongoConnection.username, password=mongoConnection.password, authSource=mongoConnection.auth_source)
+
         # Acces the database:
         db = client[conf.database_name]
         # If connection successful, print success message
@@ -57,8 +58,8 @@ def run_operation():
     elif conf.operation == 'restore_one' and conf.restore_field != '' and conf.restore_criteria != '' and conf.log_id != '':
         restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.restore_field, conf.log_id, conf.name, conf.method)
 
-    elif conf.operation == 'restore_all' and conf.log_id != '':
-        restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.log_id, conf.name, conf.method)
+    elif conf.operation == 'restore_all' and conf.restore_field != '' and conf.log_id != '':
+        restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.restore_field, conf.log_id, conf.name, conf.method)
 
     elif conf.operation == 'add_empty_field' and conf.new_field != '':
         new_field.addNullField(conf.operation, db, conf.collection_name, conf.new_field, conf.name, conf.method)

--- a/tools.py
+++ b/tools.py
@@ -54,8 +54,8 @@ def run_operation():
     elif conf.operation == 'update_with_file' and conf.update_file != '':
         update_value.updateFile(conf.operation, db, conf.collection_name, conf.update_file, conf.name, conf.method)
 
-    elif conf.operation == 'restore_one' and conf.restore_criteria != '' and conf.log_id != '':
-        restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.log_id, conf.name, conf.method)
+    elif conf.operation == 'restore_one' and conf.restore_field != '' and conf.restore_criteria != '' and conf.log_id != '':
+        restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.restore_field, conf.log_id, conf.name, conf.method)
 
     elif conf.operation == 'restore_all' and conf.log_id != '':
         restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.log_id, conf.name, conf.method)


### PR DESCRIPTION
The restore functions (restoreOne and restoreAll) and update functions (updateOne and updateAll) were modified to make them compatible with the new log entry structures which support multi-field modifications. 
-	updateOne generates log entries with the new structure
-	updateAll generates log entries with the new structure 
-	restoreOne generates log entries with the new structure
-	restoreAll  generates log entries with the new structure 
-	conf.py had minor amendments 
-	tools.py had minor amendments 
-	updateLog in log_functions.py had minor amendments   

**important note**: restoreOne, restoreAll, updateOne and updateAll still don’t support multi-field modifications. The only function that supports multi-field modifications is updateFile.
