### PR TITLE
Remove refactor

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -7,7 +7,7 @@
 # ----------
 # General information
 # ----------
-operation='' # Operations: insert, update_one, update_all, update_with_file, restore_one, restore_all, add_empty_field, rename_field, remove_field
+operation='' # Operations: insert, update_one, update_all, update_with_file, restore_one, restore_all, add_empty_field, rename_field, remove_one, remove_all
 name='' # Name of the person that does this operation.
 method='' # Method used to obtain or modify the data (e.g. Raw data EGAPRO).
 database_name='' # Name of the database.
@@ -55,5 +55,5 @@ new_field_name='' # New name for the above stated field
 # ---------
 # Remove needs:
 # ---------
-# Take into account that you will remove the information from the field in all the files in the colection.
-field_to_remove='' # Name of the field to be removed.
+remove_field='' # Target field to be removed (for remove_one and remove_all).
+remove_criteria={'stable_id':''} # Criteria for remove_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value.

--- a/conf.py
+++ b/conf.py
@@ -28,7 +28,7 @@ update_field='' # Target field to be updated (for update_one and update_all).
 new_value='' # New value for the field (for update_one and update_all).
 update_criteria={'stable_id':''} # Criteria for update_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value.
 # If using update_with_file please provide the path of the CSV/JSON with the information or the path of the directory with the CSVs/JSONs.  
-update_file = ''
+update_file=''
 # Important to consider
 ## If you want to add a list as a new value, separate the values with ";".
 ## If you want to modify an embedded/nested field, use dot notation (e.g. archived_at.crg)  
@@ -37,8 +37,9 @@ update_file = ''
 # Restore needs:
 # ----------
 restore_field='' # Target field to be restored (for restore_one and restore_all).
+log_id='' # log_id to the version to be restored (for restore_one and restore_all).
 restore_criteria={'stable_id':''} # Criteria for restore_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value. 
-log_id='' # Log id to the version to be restored (restore_all only needs this field).
+
 
 # ---------
 # Add empty field needs:

--- a/conf.py
+++ b/conf.py
@@ -36,6 +36,7 @@ update_file = ''
 # ----------
 # Restore needs:
 # ----------
+restore_field='' # Target field to be restored (for restore_one and restore_all).
 restore_criteria={'stable_id':''} # Criteria for restore_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value. 
 log_id='' # Log id to the version to be restored (restore_all only needs this field).
 

--- a/source/remove_field.py
+++ b/source/remove_field.py
@@ -8,72 +8,149 @@ __maintainer__ = "Aldar Cabrelles"
 __email__ = "aldar.cabrelles@crg.eu"
 __status__ = "development"
 
+import json
 from . import log_functions
 from pymongo import UpdateOne
 
-
-# CONSIDERATIONS:
-# IT IS IMPORTANT TO KNOW THAT YOU WILL REMOVE THE FIELD FROM ALL THE DOCUMENTS IN A COLLECTION
-def ask_user(prompt):
+def removeOne(operation, db, collection_name, remove_criteria, remove_field, name, method):
     """
-    Ask the user a yes/no question and return True for 'yes' and False for 'no'.
+    Remove a normal field or an embedded field from one document present in a specific collection from the database.
     """
-    while True:
-        response = input(f"{prompt} (yes/no): ").strip().lower()
-        if response in ['yes', 'y']:
-            return True
-        elif response in ['no', 'n']:
-            return False
-        else:
-            print("Please answer 'yes' or 'no'.")
-
-def removeField(operation, db, collection_name, field_to_remove, name, method):
-    """
-    Remove a specific field in all the documents of a collection.
-    """
-    # Confirm with the user before proceeding
-    if not ask_user(f"Are you sure you want to remove the field '{field_to_remove}' from all documents in the {collection_name} collection?"):
-        print("Operation canceled.")
-        return
 
     # Access the collection
     collection = db[collection_name]
 
-    # Check if the field exists in at least one document in the collection
-    if collection.find_one({field_to_remove: {"$exists": True}}):
-        # Insert metadata about the update process
-        process_id = log_functions.insertLog(db, name, method, operation, collection_name)
-        
-        # Prepare a list of bulk update operations
-        bulk_updates = []
-        previous_documents = collection.find({field_to_remove: {"$exists": True}})
-        
-        for previous_document in previous_documents:
-            # Get the previous value of the field
-            previous_value = previous_document.get(field_to_remove)
+    # Insert metadata about the update process in the log_details collection
+    process_id = log_functions.insertLog(db, name, method, operation, collection_name)
 
-            # Update the log field in the JSON document
-            updated_log = log_functions.updateLog(previous_document, process_id, operation, field_to_remove, previous_value, "Non-existing")
+    # Find the document to update
+    doc = collection.find_one(remove_criteria)
 
-            # Create the update operation
-            bulk_updates.append(UpdateOne(
-                {"_id": previous_document["_id"]},
-                {"$unset": {field_to_remove: ""}, "$set": {"log": updated_log}}
-            ))
+    # If the document does not exist, exit the function
+    if not doc:
+        log_functions.deleteLog(db, str(process_id))
+        print(f"Document matching criteria {remove_criteria} not found.")
+        return
 
-        # Execute the bulk update operations
-        if bulk_updates:
-            result = collection.bulk_write(bulk_updates)
-            updates_made = result.modified_count
+    # Traverse embedded fields
+    keys = remove_field.split(".")
+    current = doc # Start from the root of the document
+    parent = None # To keep track of the parent dictionary
+    last_key = None # To keep track of the last key in the path
 
-            if updates_made == 0:
-                log_functions.deleteLog(db, str(process_id))
-                print("No changes were made.")
-            else:
-                print(f'Field {field_to_remove} removed from {updates_made} documents.')
-        else:
+    # Navigate to the target field
+    for key in keys:
+        # If at any point the key does not exist, exit the function
+        if not isinstance(current, dict) or key not in current:
+            print(f"Field {remove_field} does not exist in document with stable id: {doc['stable_id']}.")
             log_functions.deleteLog(db, str(process_id))
-            print("No changes were made.")
-    else:
-        print(f"The field {field_to_remove} doesn't exist in any document in the collection.")
+            return
+        parent = current # Update parent to current before going deeper
+        last_key = key # Update last_key to the current key
+        current = current[key] # Move deeper into the document
 
+    
+    previous_value = parent[last_key] # Store the previous value for logging
+
+    # Remove the field
+    del parent[last_key]
+
+    # Build custom log entry
+    log_entry = {
+        "log_id": str(process_id),
+        "operation": operation,
+        "modified_fields": [
+            {
+                "field": remove_field,
+                "removed": previous_value if isinstance(previous_value, list) else [previous_value]
+            }
+        ]
+    }
+
+    # Merge with existing log if present
+    existing_log = [] if doc is None else doc.get("log", [])
+    existing_log.insert(0, log_entry)
+
+    # Update the document with the new log
+    result = collection.update_one({"_id": doc["_id"]}, {"$unset": {remove_field: ""}, "$set": {"log": existing_log}})
+
+    # Provide feedback
+    if result.modified_count:
+        print(f"Field {remove_field} removed from document with stable id: {doc['stable_id']}.")
+    else:
+        log_functions.deleteLog(db, str(process_id))
+        print("No changes were made.")
+
+def removeAll(operation, db, collection_name, remove_field, name, method):
+    """
+    Remove a normal field or an embedded field from all the documents present in a specific collection from the database.
+    """
+
+    # Access the collection
+    collection = db[collection_name]
+
+    # Insert metadata about the update process in the log_details collection
+    process_id = log_functions.insertLog(db, name, method, operation, collection_name)
+
+    bulk_updates = [] # To store bulk update operations
+
+    # Fetch all documents in the collection
+    prev_docs = collection.find()
+
+    # Loop through each document
+    for doc in prev_docs:
+
+        # Traverse embedded fields
+        keys = remove_field.split(".")
+        current = doc # Start from the root of the document
+        parent = None # To keep track of the parent dictionary
+        last_key = None # To keep track of the last key in the path
+
+        # Navigate to the target field
+        for key in keys:
+            # If at any point the key does not exist, skip to the next document
+            if not isinstance(current, dict) or key not in current:
+                parent = None
+                break
+            parent = current # Update parent to current before going deeper
+            last_key = key # Update last_key to the current key
+            current = current[key] # Move deeper into the document
+        
+        # If the field does not exist, skip to the next document
+        if parent is None:
+            continue
+        
+        previous_value = parent[last_key] # Store the previous value for logging
+        
+        # Build custom log entry
+        log_entry = {
+            "log_id": str(process_id),
+            "operation": operation,
+            "modified_fields": [
+                {
+                    "field": remove_field,
+                    "removed": previous_value if isinstance(previous_value, list) else [previous_value]
+                }
+            ]
+        }
+        
+        # Merge with existing log if present
+        existing_log = [] if doc is None else doc.get("log", [])
+        existing_log.insert(0, log_entry)
+        
+        # Prepare bulk update
+        bulk_updates.append(UpdateOne({"_id": doc["_id"]}, {"$unset": {remove_field: ""}, "$set": {"log": existing_log}}))
+
+    # Execute bulk update if there are any updates to be made
+    if bulk_updates:
+        result = collection.bulk_write(bulk_updates)
+        updated_count = result.modified_count or len(bulk_updates)
+    else:
+        updated_count = 0
+
+    # Provide feedback
+    if updated_count == 0:
+        log_functions.deleteLog(db, str(process_id))
+        print("No changes were made.")
+    else:
+        print(f"{updated_count} document(s) updated successfully. Removed field: {remove_field}")

--- a/source/restore_value.py
+++ b/source/restore_value.py
@@ -43,13 +43,12 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
         log_functions.deleteLog(db, str(process_id))
         print(f"log_id {log_id} not found in document.")
         return
-
-    # Find the target field entry in the log
-    target_field_log = next((mf for mf in logs[target_log_index].get("modified_fields", [])
-                             if mf.get("field") == field_name), None)
-    if not target_field_log:
+    
+    # Check if the operation is valid for restoration
+    log_operation = logs[target_log_index].get("operation", "").lower()
+    if not (log_operation.startswith("update") or log_operation.startwith("restore")):
         log_functions.deleteLog(db, str(process_id))
-        print(f"Field '{field_name}' not found in log {log_id}.")
+        print("Only update or restore operations can be restored.")
         return
 
     # Get current field value
@@ -58,27 +57,35 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
         current_value = current_value.get(key, None) if isinstance(current_value, dict) else None
         if current_value is None:
             break
+    
+    # Initialize restored_value as a list
+    restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else [] 
 
-    # Normalize to list for easier added/removed operations
-    if isinstance(current_value, list):
-        restored_value = current_value.copy()
-    elif current_value is None:
-        restored_value = []
-    else:
-        restored_value = [current_value]
+    looped_logs = 0 # Counter for logs processed
 
-    # Walk backwards through logs from latest down to (and including) target log
-    for log in reversed(logs[target_log_index:]):
-        field_entry = next((mf for mf in log.get("modified_fields", [])
-                            if mf.get("field") == field_name), None)
+    # Loop through logs from latest to target log
+    for log in logs:
+        if log.get("log_id") == log_id:
+            break
+
+        looped_logs += 1
+        print(f"Processing log entry {looped_logs}")
+
+        # Find the field entry in the modified fields
+        field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None) 
         if not field_entry:
             continue
 
-        added = field_entry.get("added", [])
-        removed = field_entry.get("removed", [])
+        added = field_entry.get("added", []) # List of values added in this log entry
+        removed = field_entry.get("removed", []) # List of values removed in this log entry
 
-        # Reverse the change: remove 'added' values, re-add 'removed' values
+        print(f"Current value from this log entry: {restored_value}")
+        print(f"Added values: {added}")
+        print(f"Removed values: {removed}") 
+
+        # Reverse the change: remove added, re-add removed
         restored_value = [x for x in restored_value if x not in added] + removed
+        print(f"Restored value after processing this log entry: {restored_value}")
 
     # Convert back to original type if it was not a list
     if not isinstance(current_value, list) and len(restored_value) <= 1:
@@ -96,92 +103,91 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
 
     # Check if the update was successful
     if result.modified_count:
-        print(f"Restored '{field_name}' to the value from log {log_id}.")
+        print(f"Field {field_name} successfully restored to the value at log_id: {log_id}.")
     else:
         print("No changes were made.")
 
-def restoreAll(operation, db, collection_name, log_id, name, method):
+def restoreAll(operation, db, collection_name, field_name, log_id, name, method):
     """
     Reset a field (embedded or non-embedded) in all documents in the collection to a previous version using log_id.
     """
     # Access the collection:
     collection = db[collection_name]
 
-    # Retrieve all documents in the collection
-    documents = collection.find()
-
-    # Insert metadata about the restore process in the meta collection
+    # Insert metadata about the restore process in the log_details collection
     process_id = log_functions.insertLog(db, name, method, operation, collection_name)
-    if not process_id:
-        print('Failed to create log for the restore process.')
-        return
 
     restored_documents = 0
     
-    for document in documents:
-        log_entries = document.get('log', [])
+    # Iterate through all documents in the collection
+    for doc in collection.find():
+        # Retrieve the logs 
+        logs = doc.get("log", [])
+        target_log_index = None
+
+        # Find the target log entry by log_id
+        for i, log in enumerate(logs):
+            if log.get("log_id") == log_id:
+                target_log_index = i
+                break
         
-        # Find the log entry to restore
-        log_entry = next((entry for entry in log_entries if entry.get('log_id') == log_id), None)
-        
-        if not log_entry:
-            print(f"The log_id {log_id} does not exist in the document with _id {document['_id']}")
+        # If the log_id is not found, skip this document
+        if target_log_index is None:
+            print(f"log_id {log_id} not found in document {doc.get('stable_id')}")
             continue
 
-        if 'update' not in log_entry.get('operation') and 'restore' not in log_entry.get('operation'):
-            print(f"Only update|restore operations can be restored in document with _id {document['_id']}")
+        # Check if the operation is valid for restoration
+        log_operation = logs[target_log_index].get("operation", "").lower()
+        if not (log_operation.startswith("update") or log_operation.startswith("restore")):
+            print(f"Only update or restore operations can be restored. Skipping document {doc.get('stable_id')}")
             continue
 
-        # Get the field and value to restore
-        modified_field = log_entry.get('modified_field')
-
-        # Retrieve current value (handle embedded fields)
-        current_value = document
-        for key in modified_field.split("."):
-            current_value = current_value.get(key, None)
+        # Get current field value
+        current_value = doc
+        for key in field_name.split("."):
+            current_value = current_value.get(key, None) if isinstance(current_value, dict) else None
             if current_value is None:
                 break
-        
-        current_value_list = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
-        
-        looped_logs = 0
-        restored_value_list = current_value_list
 
-        # Loop through log entries to compute the restored value
-        for entry in log_entries:
-            if entry.get('log_id') == log_id:
+        # Initialize restored_value as a list
+        restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
+
+        looped_logs = 0  # Counter for logs processed
+
+        # Loop through logs from latest to target log
+        for log in logs:
+            if log.get("log_id") == log_id:
                 break
+            
+            looped_logs += 1
 
-            if entry.get('modified_field') == modified_field:
-                looped_logs += 1
-                added_value_list = entry.get('changed_values', {}).get('added', [])
-                removed_value_list = entry.get('changed_values', {}).get('removed', [])
+            # Find the field entry in the modified fields
+            field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None)
+            if not field_entry:
+                continue
 
-                # Compute the restored value
-                restored_value_list = [x for x in restored_value_list if x not in added_value_list] + removed_value_list
-        
-        # Convert single-element lists to a normal string
-        restored_value_list = restored_value_list[0] if len(restored_value_list) == 1 else restored_value_list
+            added = field_entry.get("added", []) # List of values added in this log entry
+            removed = field_entry.get("removed", []) # List of values removed in this log entry
 
-        # Check if the restored value is equal to the current value
-        if restored_value_list == current_value or restored_value_list == current_value_list:
-            print(f"No changes needed for document stable_id {document['stable_id']}, the current value is already equal to the restored value.")
-            continue
+            # Reverse the change: remove added, re-add removed
+            restored_value = [x for x in restored_value if x not in added] + removed
 
-        # Create the log object for this operation
-        updated_log = log_functions.updateLog(document, process_id, operation, modified_field, current_value, restored_value_list)
+        # Convert back to original type if needed
+        if not isinstance(current_value, list) and len(restored_value) <= 1:
+            restored_value = restored_value[0] if restored_value else None
 
-        # Update the document
-        result = collection.update_one(
-            {"_id": document["_id"]},
-            {"$set": {modified_field: restored_value_list, "log": updated_log}}
-        )
+        # Check if the restored value is different from the current value
+        if restored_value != current_value:
+            # Update the log with the restoration details
+            updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)
+            # Update the document with the restored value and updated log 
+            result = collection.update_one({"_id": doc["_id"]}, {"$set": {field_name: restored_value, "log": updated_log}}) 
+            if result.modified_count:
+                restored_documents += 1
 
-        if result.modified_count > 0:
-            restored_documents += 1
-    
+    # Check if any documents were restored
     if restored_documents == 0:
         log_functions.deleteLog(db, str(process_id))
         print("No changes were made.")
     else:
-        print(f'Field {modified_field} restored successfully to the values at log {log_id} in {restored_documents} documents.')
+        print(f"Field {field_name} successfully restored to the values at log {log_id} in {restored_documents} documents.")

--- a/source/update_value.py
+++ b/source/update_value.py
@@ -60,17 +60,15 @@ def updateOne(operation, db, collection_name, update_criteria, update_field, new
         # If the field doesn't exist in the document, explicitly set `None` as the current value
         if current_value is None:
             print(f"Field {update_field} doesn't exist or has no value in the document. Creating field and setting new value.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [None]}
         elif current_value != new_value_list:
             print(f"Field {update_field} exists and has a different value in document with stable_id: {list(update_criteria.values())[0]}. Updating the field.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [current_value]}
         else:
             print(f"Field {update_field} exists but has the same value in document with stable_id: {list(update_criteria.values())[0]}. No update required.")
             log_functions.deleteLog(db, str(process_id))
             return  # Exit the function without performing the update if values are the same
 
         # Update the log with the modified field
-        updated_log = log_functions.updateLogNew(previous_document, process_id, operation, modified_field)
+        updated_log = log_functions.updateLog(previous_document, process_id, operation, update_field, current_value if current_value is not None else None, new_value_list)
         # Update the document with the new data
         result = collection.update_one(update_criteria, {"$set": {update_field: new_value_list, "log": updated_log}})
             
@@ -130,19 +128,16 @@ def updateAll(operation, db, collection_name, update_field, new_value, name, met
         if current_value is None:
             # If the field is set as Null or doesn't exist, create it and set the new value
             print(f"Field {update_field} doesn't exist or has no value in document with stable_id: {stable_id}. Creating field and setting new value.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [None]}
-
         elif current_value != new_value_list:
             # If the field exists but the value is different, update it
             print(f"Field {update_field} exists and has a different value in document with stable_id: {stable_id}. Updating the field.")
-            modified_field = {"field": update_field, "added": [new_value_list], "removed": [current_value]}
         else:
             # If the field exists and the value is the same, no update is needed
             print(f"Field {update_field} exists but has the same value in document with stable_id: {stable_id}. No update required.")
             continue  # Skip to the next document if no update is needed
 
         # Update the log with the modified field
-        updated_log = log_functions.updateLogNew(document, process_id, operation, modified_field)
+        updated_log = log_functions.updateLog(document, process_id, operation, update_field, current_value if current_value is not None else None, new_value_list)
         # Prepare the bulk update operation
         bulk_updates.append(UpdateOne({"_id": document["_id"]}, {"$set": {update_field: new_value_list, "log": updated_log}}))
 

--- a/tools.py
+++ b/tools.py
@@ -25,6 +25,7 @@ def connect_mongo():
     try:
         # Connect to MongoDB
         client = MongoClient(mongoConnection.mongo_host, mongoConnection.mongo_port, username=mongoConnection.username, password=mongoConnection.password, authSource=mongoConnection.auth_source)
+
         # Acces the database:
         db = client[conf.database_name]
         # If connection successful, print success message
@@ -57,8 +58,8 @@ def run_operation():
     elif conf.operation == 'restore_one' and conf.restore_field != '' and conf.restore_criteria != '' and conf.log_id != '':
         restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.restore_field, conf.log_id, conf.name, conf.method)
 
-    elif conf.operation == 'restore_all' and conf.log_id != '':
-        restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.log_id, conf.name, conf.method)
+    elif conf.operation == 'restore_all' and conf.restore_field != '' and conf.log_id != '':
+        restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.restore_field, conf.log_id, conf.name, conf.method)
 
     elif conf.operation == 'add_empty_field' and conf.new_field != '':
         new_field.addNullField(conf.operation, db, conf.collection_name, conf.new_field, conf.name, conf.method)

--- a/tools.py
+++ b/tools.py
@@ -28,6 +28,7 @@ def connect_mongo():
 
         # Acces the database:
         db = client[conf.database_name]
+
         # If connection successful, print success message
         print("Connection to BioMongoDB established.")
 
@@ -67,8 +68,11 @@ def run_operation():
     elif conf.operation == 'rename_field' and conf.field_name != '' and conf.new_field_name != '':
         rename_field.renameField(conf.operation, db, conf.collection_name, conf.field_name, conf.new_field_name, conf.name, conf.method)
 
-    elif conf.operation == 'remove_field' and conf.field_to_remove != '':
-        remove_field.removeField(conf.operation, db, conf.collection_name, conf.field_to_remove, conf.name, conf.method)
+    elif conf.operation == 'remove_one' and conf.remove_field != '' and conf.remove_criteria != '':
+        remove_field.removeOne(conf.operation, db, conf.collection_name, conf.remove_criteria, conf.remove_field, conf.name, conf.method)
+    
+    elif conf.operation == 'remove_all' and conf.remove_field != '':
+        remove_field.removeAll(conf.operation, db, conf.collection_name, conf.remove_field, conf.name, conf.method)
 
     else:
         print('Something is missing in the conf.py file')
@@ -77,7 +81,7 @@ def main():
     if conf.operation == '' and conf.database_name == '' and conf.collection_name == '' and conf.name == '' and conf.method == '':
         # First print help message just in case.
         print_help()
-    elif conf.operation == '' or conf.operation not in ['insert', 'update_one', 'update_all', 'update_with_file', 'restore_one', 'restore_all', 'add_empty_field', 'rename_field', 'remove_field']:
+    elif conf.operation == '' or conf.operation not in ['insert', 'update_one', 'update_all', 'update_with_file', 'restore_one', 'restore_all', 'add_empty_field', 'rename_field', 'remove_one', 'remove_all']:
         print("Operation is missing or wrong.")
     elif conf.database_name == '':
         print("Database is missing.")

--- a/tools.py
+++ b/tools.py
@@ -54,8 +54,8 @@ def run_operation():
     elif conf.operation == 'update_with_file' and conf.update_file != '':
         update_value.updateFile(conf.operation, db, conf.collection_name, conf.update_file, conf.name, conf.method)
 
-    elif conf.operation == 'restore_one' and conf.restore_criteria != '' and conf.log_id != '':
-        restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.log_id, conf.name, conf.method)
+    elif conf.operation == 'restore_one' and conf.restore_field != '' and conf.restore_criteria != '' and conf.log_id != '':
+        restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.restore_field, conf.log_id, conf.name, conf.method)
 
     elif conf.operation == 'restore_all' and conf.log_id != '':
         restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.log_id, conf.name, conf.method)


### PR DESCRIPTION
The script remove_field.py had a major refactor. Now:

- there is a function for removing one field from one document (removeOne) as well as for removing one field from all the documents in one collection (removeAll)
- both functions support the removal of embedded and non-embedded fields
- the functions create log entries compatible with the new logging system  
