### PR TITLE
Refactored restore functions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -36,8 +36,7 @@ update_file=''
 # ----------
 # Restore needs:
 # ----------
-restore_field='' # Target field to be restored (for restore_one and restore_all).
-log_id='' # log_id to the version to be restored (for restore_one and restore_all).
+log_id='' # log_id to the version to be restored (for restore_one, restore_all and restore_all_multifield).
 restore_criteria={'stable_id':''} # Criteria for restore_one, the first element should be the field name to match (stable_id), and the second should be the actual stable_id value. 
 
 

--- a/source/restore_value.py
+++ b/source/restore_value.py
@@ -154,35 +154,41 @@ def restoreAll(operation, db, collection_name, field_name, log_id, name, method)
         looped_logs = 0  # Counter for logs processed
 
         # Loop through logs from latest to target log
-        for log in logs:
-            if log.get("log_id") == log_id:
-                break
-            
+        for log in logs:         
             looped_logs += 1
 
             # Find the field entry in the modified fields
             field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None)
-            if not field_entry:
-                continue
+            if field_entry:
+                added = field_entry.get("added", []) # List of values added in this log entry
+                removed = field_entry.get("removed", []) # List of values removed in this log entry
 
-            added = field_entry.get("added", []) # List of values added in this log entry
-            removed = field_entry.get("removed", []) # List of values removed in this log entry
+                # Reverse the change: remove added, re-add removed
+                restored_value = [x for x in restored_value if x not in added] + removed
+                
+            if log.get("log_id") == log_id:
+                break
 
-            # Reverse the change: remove added, re-add removed
-            restored_value = [x for x in restored_value if x not in added] + removed
+        # Check if the restored value is the same as the current value
+        if restored_value == current_value:
+            print(f"No changes needed for document {doc.get('stable_id')}. Field already matches target state.")
+            continue  
 
-        # Convert back to original type if needed
-        if not isinstance(current_value, list) and len(restored_value) <= 1:
-            restored_value = restored_value[0] if restored_value else None
+        # Convert back to scalar only if the original field was not a list
+        if not isinstance(current_value, list) and isinstance(restored_value, list) and len(restored_value) <= 1:
+            restored_value = restored_value[0] if restored_value else None      
 
-        # Check if the restored value is different from the current value
-        if restored_value != current_value:
-            # Update the log with the restoration details
-            updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)
-            # Update the document with the restored value and updated log 
-            result = collection.update_one({"_id": doc["_id"]}, {"$set": {field_name: restored_value, "log": updated_log}}) 
-            if result.modified_count:
-                restored_documents += 1
+        # Update the document with the restored value and updated log
+        updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)
+
+        # Update the document with the restored value and updated log
+        result = collection.update_one(
+            {"_id": doc["_id"]}, 
+            {"$set": {field_name: restored_value, "log": updated_log}}
+        )
+
+        if result.modified_count:
+            restored_documents += 1
 
     # Check if any documents were restored
     if restored_documents == 0:

--- a/source/restore_value.py
+++ b/source/restore_value.py
@@ -65,37 +65,36 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
 
     # Loop through logs from latest to target log
     for log in logs:
-        if log.get("log_id") == log_id:
-            break
-
         looped_logs += 1
-        print(f"Processing log entry {looped_logs}")
+        print(f"Processing log entry {looped_logs}")    
 
         # Find the field entry in the modified fields
         field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None) 
-        if not field_entry:
-            continue
+        if field_entry:
+            added = field_entry.get("added", []) # List of values added in this log entry
+            removed = field_entry.get("removed", []) # List of values removed in this log entry
 
-        added = field_entry.get("added", []) # List of values added in this log entry
-        removed = field_entry.get("removed", []) # List of values removed in this log entry
+            print(f"Current value from this log entry: {restored_value}")
+            print(f"Added values: {added}")
+            print(f"Removed values: {removed}") 
 
-        print(f"Current value from this log entry: {restored_value}")
-        print(f"Added values: {added}")
-        print(f"Removed values: {removed}") 
+            # Reverse the change: remove added, re-add removed
+            restored_value = [x for x in restored_value if x not in added] + removed
+            print(f"Restored value after processing this log entry: {restored_value}")
 
-        # Reverse the change: remove added, re-add removed
-        restored_value = [x for x in restored_value if x not in added] + removed
-        print(f"Restored value after processing this log entry: {restored_value}")
-
-    # Convert back to original type if it was not a list
-    if not isinstance(current_value, list) and len(restored_value) <= 1:
-        restored_value = restored_value[0] if restored_value else None
+        if log.get("log_id") == log_id:
+            print(f"Reached target log entry with log_id: {log_id}. Stopping log processing.")
+            break
 
     # Check if the restored value is the same as the current value
     if restored_value == current_value:
         log_functions.deleteLog(db, str(process_id))
         print("No changes needed. Field already matches target state.")
         return
+    
+    # Convert back to scalar only if the original field was not a list
+    if not isinstance(current_value, list) and isinstance(restored_value, list) and len(restored_value) <= 1:
+        restored_value = restored_value[0] if restored_value else None
 
     # Update the document
     updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)

--- a/source/restore_value.py
+++ b/source/restore_value.py
@@ -10,40 +10,40 @@ __status__ = "development"
 
 from . import log_functions
 
-def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_id, name, method):
+def restoreOne(operation, db, collection_name, restore_criteria, log_id, name, method):
     """
-    Reset the value of a field (embedded or non-embedded) in a document to a previous version using the log_id.
+    Restore all fields modified in the target log entry for one document.
+    The fields to restore are taken from the modified_fields section of the matching log entry.
+    One restore log entry is created for the document.
     """
-    # Access the collection:
+    # Access the collection
     collection = db[collection_name]
 
     # Find the document
-    doc = collection.find_one(reset_criteria)
-    
-    # Check if the document exists
+    doc = collection.find_one(restore_criteria)
+
     if not doc:
-        print(f"The document you are searching for is not in the collection.")
+        print("The document you are searching for is not in the collection.")
         return
 
     # Insert metadata about the restore process in the log_details collection
     process_id = log_functions.insertLog(db, name, method, operation, collection_name)
 
-    # Retrieve the logs
-    logs = doc.get('log', [])
+    # Retrieve logs
+    logs = doc.get("log", [])
 
     # Find the target log entry by log_id
-    target_log_index = None # Set to None to indicate not found
+    target_log_index = None
     for i, log in enumerate(logs):
         if log.get("log_id") == log_id:
             target_log_index = i
             break
 
-    # If the log_id is not found, delete the log and exit
     if target_log_index is None:
         log_functions.deleteLog(db, str(process_id))
         print(f"log_id {log_id} not found in document.")
         return
-    
+
     # Check if the operation is valid for restoration
     log_operation = logs[target_log_index].get("operation", "").lower()
     if not (log_operation.startswith("update") or log_operation.startswith("restore")):
@@ -51,94 +51,22 @@ def restoreOne(operation, db, collection_name, reset_criteria, field_name, log_i
         print("Only update or restore operations can be restored.")
         return
 
-    # Get current field value
-    current_value = doc
-    for key in field_name.split("."):
-        current_value = current_value.get(key, None) if isinstance(current_value, dict) else None
-        if current_value is None:
-            break
-    
-    # Initialize restored_value as a list
-    restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else [] 
+    # Get fields to restore from the target log entry
+    target_modified_fields = logs[target_log_index].get("modified_fields", [])
 
-    looped_logs = 0 # Counter for logs processed
-
-    # Loop through logs from latest to target log
-    for log in logs:
-        looped_logs += 1
-        print(f"Processing log entry {looped_logs}")    
-
-        # Find the field entry in the modified fields
-        field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None) 
-        if field_entry:
-            added = field_entry.get("added", []) # List of values added in this log entry
-            removed = field_entry.get("removed", []) # List of values removed in this log entry
-
-            print(f"Current value from this log entry: {restored_value}")
-            print(f"Added values: {added}")
-            print(f"Removed values: {removed}") 
-
-            # Reverse the change: remove added, re-add removed
-            restored_value = [x for x in restored_value if x not in added] + removed
-            print(f"Restored value after processing this log entry: {restored_value}")
-
-        if log.get("log_id") == log_id:
-            print(f"Reached target log entry with log_id: {log_id}. Stopping log processing.")
-            break
-
-    # Check if the restored value is the same as the current value
-    if restored_value == current_value:
+    if not target_modified_fields:
         log_functions.deleteLog(db, str(process_id))
-        print("No changes needed. Field already matches target state.")
+        print("No modified fields found in target log.")
         return
-    
-    # Convert back to scalar only if the original field was not a list
-    if not isinstance(current_value, list) and isinstance(restored_value, list) and len(restored_value) <= 1:
-        restored_value = restored_value[0] if restored_value else None
 
-    # Update the document
-    updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)
-    result = collection.update_one(reset_criteria, {"$set": {field_name: restored_value, "log": updated_log}})
+    update_fields = {}
+    new_modified_fields = []
 
-    # Check if the update was successful
-    if result.modified_count:
-        print(f"Field {field_name} successfully restored to the value at log_id: {log_id}.")
-    else:
-        print("No changes were made.")
+    # Restore each field present in the target log entry
+    for target_field_entry in target_modified_fields:
+        field_name = target_field_entry.get("field")
 
-def restoreAll(operation, db, collection_name, field_name, log_id, name, method):
-    """
-    Reset a field (embedded or non-embedded) in all documents in the collection to a previous version using log_id.
-    """
-    # Access the collection:
-    collection = db[collection_name]
-
-    # Insert metadata about the restore process in the log_details collection
-    process_id = log_functions.insertLog(db, name, method, operation, collection_name)
-
-    restored_documents = 0
-    
-    # Iterate through all documents in the collection
-    for doc in collection.find():
-        # Retrieve the logs 
-        logs = doc.get("log", [])
-        target_log_index = None
-
-        # Find the target log entry by log_id
-        for i, log in enumerate(logs):
-            if log.get("log_id") == log_id:
-                target_log_index = i
-                break
-        
-        # If the log_id is not found, skip this document
-        if target_log_index is None:
-            print(f"log_id {log_id} not found in document {doc.get('stable_id')}")
-            continue
-
-        # Check if the operation is valid for restoration
-        log_operation = logs[target_log_index].get("operation", "").lower()
-        if not (log_operation.startswith("update") or log_operation.startswith("restore")):
-            print(f"Only update or restore operations can be restored. Skipping document {doc.get('stable_id')}")
+        if not field_name:
             continue
 
         # Get current field value
@@ -149,50 +77,235 @@ def restoreAll(operation, db, collection_name, field_name, log_id, name, method)
                 break
 
         # Initialize restored_value as a list
-        restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
+        restored_value = (
+            current_value
+            if isinstance(current_value, list)
+            else [current_value]
+            if current_value is not None
+            else []
+        )
 
-        looped_logs = 0  # Counter for logs processed
+        looped_logs = 0
 
-        # Loop through logs from latest to target log
-        for log in logs:         
+        # Loop through logs from latest to target log, INCLUDING target log
+        for log in logs:
             looped_logs += 1
+            print(f"Processing log entry {looped_logs} for field '{field_name}'")
 
-            # Find the field entry in the modified fields
-            field_entry = next((mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name), None)
+            field_entry = next(
+                (mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name),
+                None
+            )
+
             if field_entry:
-                added = field_entry.get("added", []) # List of values added in this log entry
-                removed = field_entry.get("removed", []) # List of values removed in this log entry
+                added = field_entry.get("added", [])
+                removed = field_entry.get("removed", [])
+
+                print(f"Current value from this log entry: {restored_value}")
+                print(f"Added values: {added}")
+                print(f"Removed values: {removed}")
 
                 # Reverse the change: remove added, re-add removed
                 restored_value = [x for x in restored_value if x not in added] + removed
-                
-            if log.get("log_id") == log_id:
-                break
 
-        # Check if the restored value is the same as the current value
-        if restored_value == current_value:
-            print(f"No changes needed for document {doc.get('stable_id')}. Field already matches target state.")
-            continue  
+                print(f"Restored value after processing this log entry: {restored_value}")
+
+            if log.get("log_id") == log_id:
+                print(f"Reached target log entry with log_id: {log_id}. Stopping log processing for field '{field_name}'.")
+                break
 
         # Convert back to scalar only if the original field was not a list
         if not isinstance(current_value, list) and isinstance(restored_value, list) and len(restored_value) <= 1:
-            restored_value = restored_value[0] if restored_value else None      
+            restored_value = restored_value[0] if restored_value else None
 
-        # Update the document with the restored value and updated log
-        updated_log = log_functions.updateLog(doc, process_id, operation, field_name, current_value, restored_value)
+        # Store only actual changes
+        if restored_value != current_value:
+            update_fields[field_name] = restored_value
 
-        # Update the document with the restored value and updated log
+            current_as_list = (
+                current_value
+                if isinstance(current_value, list)
+                else [current_value]
+                if current_value is not None
+                else []
+            )
+
+            restored_as_list = (
+                restored_value
+                if isinstance(restored_value, list)
+                else [restored_value]
+                if restored_value is not None
+                else []
+            )
+
+            new_modified_fields.append({
+                "field": field_name,
+                "added": restored_as_list,
+                "removed": current_as_list
+            })
+
+    # If no fields changed, delete process log and exit
+    if not update_fields:
+        log_functions.deleteLog(db, str(process_id))
+        print("No changes needed. Fields already match target state.")
+        return
+
+    # Create one new restore log entry for all restored fields
+    new_log_entry = {
+        "log_id": str(process_id),
+        "operation": operation,
+        "modified_fields": new_modified_fields
+    }
+
+    # Keep newest-to-oldest order
+    updated_log = [new_log_entry] + logs
+
+    # Update the document
+    result = collection.update_one(
+        restore_criteria,
+        {
+            "$set": {
+                **update_fields,
+                "log": updated_log
+            }
+        }
+    )
+
+    if result.modified_count:
+        restored_field_names = ", ".join(update_fields.keys())
+        print(f"Fields successfully restored to the values at log_id {log_id}: {restored_field_names}.")
+    else:
+        log_functions.deleteLog(db, str(process_id))
+        print("No changes were made.")
+
+def restoreAll(operation, db, collection_name, log_id, name, method):
+    """
+    Reset all fields modified in the target log entry for all documents in the collection using the log_id.
+    """
+    # Access the collection
+    collection = db[collection_name]
+
+    # Insert metadata about the restore process in the log_details collection
+    process_id = log_functions.insertLog(db, name, method, operation, collection_name)
+
+    restored_documents = 0
+
+    # Iterate through all documents in the collection
+    for doc in collection.find():
+        logs = doc.get("log", [])
+        target_log_index = None
+
+        # Find the target log entry by log_id
+        for i, log in enumerate(logs):
+            if log.get("log_id") == log_id:
+                target_log_index = i
+                break
+
+        # Skip documents where the log_id is not found
+        if target_log_index is None:
+            print(f"log_id {log_id} not found in document {doc.get('stable_id')}")
+            continue
+
+        # Check if the operation is valid for restoration
+        log_operation = logs[target_log_index].get("operation", "").lower()
+        if not (log_operation.startswith("update") or log_operation.startswith("restore")):
+            print(f"Only update or restore operations can be restored. Skipping document {doc.get('stable_id')}")
+            continue
+
+        # Get modified fields from the target log
+        target_modified_fields = logs[target_log_index].get("modified_fields", [])
+        if not target_modified_fields:
+            print(f"No modified fields found in target log for document {doc.get('stable_id')}")
+            continue
+
+        update_fields = {}
+        new_modified_fields = []
+
+        # Process each field mentioned in the target log
+        for target_field_entry in target_modified_fields:
+            field_name = target_field_entry.get("field")
+            if not field_name:
+                continue
+
+            # Get current field value
+            current_value = doc
+            for key in field_name.split("."):
+                current_value = current_value.get(key, None) if isinstance(current_value, dict) else None
+                if current_value is None:
+                    break
+
+            # Initialize restored_value
+            restored_value = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
+
+            looped_logs = 0
+
+            # Process logs from newest to oldest, INCLUDING the target log
+            for log in logs:
+                looped_logs += 1
+                print(f"Processing log entry {looped_logs} for field '{field_name}' in document {doc.get('stable_id')}")
+
+                field_entry = next(
+                    (mf for mf in log.get("modified_fields", []) if mf.get("field") == field_name),
+                    None
+                )
+
+                if field_entry:
+                    added = field_entry.get("added", [])
+                    removed = field_entry.get("removed", [])
+
+                    restored_value = [x for x in restored_value if x not in added] + removed
+                    #print(f"Restored value after processing this log entry: {restored_value}")
+
+                if log.get("log_id") == log_id:
+                    #print(f"Reached target log entry with log_id: {log_id}. Stopping log processing for field '{field_name}'.")
+                    break
+
+            # Convert back to scalar only if original field was not a list
+            if not isinstance(current_value, list) and isinstance(restored_value, list) and len(restored_value) <= 1:
+                restored_value = restored_value[0] if restored_value else None
+
+            # Keep only fields that actually changed
+            if restored_value != current_value:
+                update_fields[field_name] = restored_value
+
+                # Build one entry for the combined restore log
+                current_as_list = current_value if isinstance(current_value, list) else [current_value] if current_value is not None else []
+                restored_as_list = restored_value if isinstance(restored_value, list) else [restored_value] if restored_value is not None else []
+
+                new_modified_fields.append({
+                    "field": field_name,
+                    "added": restored_as_list,
+                    "removed": current_as_list
+                })
+
+        # If no fields changed, skip this document
+        if not update_fields:
+            print(f"No changes needed for document {doc.get('stable_id')}.")
+            continue
+
+        # Create one new log entry for the whole restore
+        current_log = doc.get("log", [])
+        new_log_entry = {
+            "log_id": str(process_id),
+            "operation": operation,
+            "modified_fields": new_modified_fields
+        }
+
+        # Keep newest-to-oldest ordering
+        updated_log = [new_log_entry] + current_log
+
+        # Update document
         result = collection.update_one(
-            {"_id": doc["_id"]}, 
-            {"$set": {field_name: restored_value, "log": updated_log}}
+            {"_id": doc["_id"]},
+            {"$set": {**update_fields, "log": updated_log}}
         )
 
         if result.modified_count:
             restored_documents += 1
 
-    # Check if any documents were restored
+    # Final result
     if restored_documents == 0:
         log_functions.deleteLog(db, str(process_id))
         print("No changes were made.")
     else:
-        print(f"Field {field_name} successfully restored to the values at log {log_id} in {restored_documents} documents.")
+        print(f"Fields from log {log_id} were successfully restored in {restored_documents} documents.")

--- a/tools.py
+++ b/tools.py
@@ -56,12 +56,12 @@ def run_operation():
     elif conf.operation == 'update_with_file' and conf.update_file != '':
         update_value.updateFile(conf.operation, db, conf.collection_name, conf.update_file, conf.name, conf.method)
 
-    elif conf.operation == 'restore_one' and conf.restore_field != '' and conf.restore_criteria != '' and conf.log_id != '':
-        restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.restore_field, conf.log_id, conf.name, conf.method)
+    elif conf.operation == 'restore_one' and conf.restore_criteria != '' and conf.log_id != '':
+        restore_value.restoreOne(conf.operation, db, conf.collection_name, conf.restore_criteria, conf.log_id, conf.name, conf.method)
 
-    elif conf.operation == 'restore_all' and conf.restore_field != '' and conf.log_id != '':
-        restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.restore_field, conf.log_id, conf.name, conf.method)
-
+    elif conf.operation == 'restore_all' and conf.log_id != '':
+        restore_value.restoreAll(conf.operation, db, conf.collection_name, conf.log_id, conf.name, conf.method)
+    
     elif conf.operation == 'add_empty_field' and conf.new_field != '':
         new_field.addNullField(conf.operation, db, conf.collection_name, conf.new_field, conf.name, conf.method)
 


### PR DESCRIPTION
Refactored restoreOne and restoreAll so that they can handle multi-field restore actions.

- now there's no need to provide the name of the field that needs to be restored. The functions will restore the values of all the fields present in the log entry where the given log_id is present
- minor change to the config file  